### PR TITLE
Query remembering & PageModel refactor

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Chirp!";
     Layout = "Shared/_Layout";
     int currentPage = 1;
-    var pageQuery = Model.HttpContext.Request.Query["page"];
+    var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);
@@ -14,7 +14,7 @@
 
 <div>
     <form method="post" asp-page-handler="Search">
-        <input style="float: left" type="text" asp-for="SearchText">
+        <input style="float: left" type="text" asp-for="Search">
         <input type="submit" value="Search">
     </form>
     <br/>
@@ -26,7 +26,7 @@
         <h2> Public Timeline </h2>
         <div class="cheepbox">
             <h3>What's on your mind @(User.Identity.Name)?</h3>
-            <form method="post" asp-page-handler="Cheep">
+            <form method="post" asp-page-handler="Cheep" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex">
                 <input style="float: left" type="text" asp-for="Text">
                 <input type="submit" value="Share">
             </form>
@@ -47,14 +47,14 @@
                                 var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                 if (isFollowing && User.Identity.Name != cheep.Author.Name)
                                 {
-                                    <form method="post" asp-page-handler="Unfollow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                             value="@cheep.Author.Name">unfollow</button>
                                     </form>
                                 }
                                 else if (User.Identity.Name != cheep.Author.Name)
                                 {
-                                    <form method="post" asp-page-handler="Follow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                             value="@cheep.Author.Name">follow</button>
                                     </form>
@@ -62,12 +62,12 @@
 
                                 var isSaved = await Model.IsSavedAsync(cheep);
                                 if (isSaved) {
-                                    <form method="post" asp-page-handler="RemoveSave" style="display:inline;">
+                                    <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unsave"
                                             value="@cheep.CheepId">unsave</button>
                                     </form>
                                 } else {
-                                    <form method="post" asp-page-handler="Save" style="display:inline;">
+                                    <form method="post" asp-page-handler="Save" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="save"
                                             value="@cheep.CheepId">save</button>
                                     </form>
@@ -84,11 +84,11 @@
         <div class="pagination">
             @if (currentPage > 1)
             {
-                <a href="/?page=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+                <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
             }
             <span>Page @currentPage</span>
 
-            <a id="next" href="/?page=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
+            <a id="next" href="/?pageIndex=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
         </div>
     }
     else
@@ -97,7 +97,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/?page=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+            <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
         }
         <span>Page @currentPage</span>
     }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,37 +1,21 @@
 ﻿namespace Chirp.Web.Pages;
 
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Repositories;
 
-public class PublicModel : PageModel
+public class PublicModel : CheepPageModel
 {
-    private readonly IAuthorRepository _authorRepository;
-    private readonly ICheepRepository _cheepRepository;
-    public required List<CheepDTO> Cheeps { get; set; }
 
-    [BindProperty]
-    public string? Text { get; set; }
-    [BindProperty]
-    public string? SearchText { get; set; }
-    [BindProperty]
-    public string? Follow { get; set; }
-    [BindProperty]
-    public string? Unfollow { get; set; }
-    [BindProperty]
-    public long? Save { get; set; }
-    [BindProperty]
-    public long? Unsave { get; set; }
-
-    public PublicModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository)
-    {
-        _cheepRepository = cheepRepository;
-        _authorRepository = authorRepository;
-    }
+    public PublicModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository) 
+        : base(cheepRepository, authorRepository)
+    { }
 
     public async Task<ActionResult> OnGet()
     {
-        string? page = HttpContext.Request.Query["page"];
+        string? page = HttpContext.Request.Query["PageIndex"];
         int pageNum = 1;
         if (page != null)
         {
@@ -47,122 +31,5 @@ public class PublicModel : PageModel
             Cheeps = await _cheepRepository.ReadCheeps(null, (pageNum - 1) * 32, 32);
         }
         return Page();
-    }
-
-    public async Task<ActionResult> OnPostCheepAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-
-        var cheep = new CheepDTO
-        {
-            Author = author!,
-            Text = Text!,
-            TimeStamp = DateTime.Now
-        };
-        await _cheepRepository.CreateCheep(cheep);
-
-        return RedirectToPage("Public");
-    }
-
-    public async Task<ActionResult> OnPostFollowAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-
-
-        var followAuthor = await _authorRepository.GetAuthorByName(Follow!);
-        await _authorRepository.Follow(author!, followAuthor!);
-
-
-        return RedirectToPage("Public");
-
-    }
-
-    public async Task<ActionResult> OnPostUnfollowAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-        var followAuthor = await _authorRepository.GetAuthorByName(Unfollow!);
-        await _authorRepository.UnFollow(author!, followAuthor!);
-
-
-        return RedirectToPage("Public");
-    }
-
-    public async Task<ActionResult> OnPostSaveAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        var cheep = await _cheepRepository.GetCheepById((long)Save!);
-
-        await _cheepRepository.SaveCheep(author!, cheep!);
-
-        return RedirectToPage("Public");
-    }
-
-    public async Task<ActionResult> OnPostRemoveSaveAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        var cheep = await _cheepRepository.GetCheepById((long)Unsave!);
-
-        await _cheepRepository.RemoveSavedCheep(author!, cheep!);
-
-        return RedirectToPage("Public");
-    }
-
-    // Curr follows target....
-    public async Task<bool> IsFollowingAsync(string currentUserName, string targetUserName)
-    {
-        // get curr DTO
-        var currentUser = await _authorRepository.GetAuthorByName(currentUserName);
-
-        // get auth DTO
-        var targetUser = await _authorRepository.GetAuthorByName(targetUserName);
-        if (targetUser == currentUser) throw new Exception("You cannot follow this yourself!");
-        if (targetUser == null || currentUser == null) throw new Exception("null :(");
-        var result = await _authorRepository.IsFollowing(currentUser, targetUser);
-
-        return result;
-
-    }
-
-    public async Task<bool> IsSavedAsync(CheepDTO cheep)
-    {
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        
-        return await _cheepRepository.IsSaved(author!, cheep);
-
-    }
-
-    public ActionResult OnPostSearch()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        return RedirectToPage("Public", new { search = SearchText });
     }
 }

--- a/src/Chirp.Web/Pages/Saved.cshtml
+++ b/src/Chirp.Web/Pages/Saved.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Chirp!";
     Layout = "Shared/_Layout";
     int currentPage = 1;
-    var pageQuery = Model.HttpContext.Request.Query["page"];
+    var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);
@@ -32,20 +32,20 @@
                                 var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                 if (isFollowing && User.Identity.Name != cheep.Author.Name)
                                 {
-                                    <form method="post" asp-page-handler="Unfollow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                             value="@cheep.Author.Name">unfollow</button>
                                     </form>
                                 }
                                 else if (User.Identity.Name != cheep.Author.Name)
                                 {
-                                    <form method="post" asp-page-handler="Follow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                             value="@cheep.Author.Name">follow</button>
                                     </form>
                                 }
 
-                                <form method="post" asp-page-handler="RemoveSave" style="display:inline;">
+                                <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                     <button type="submit" class="btn btn-link p-0" name="unsave"
                                         value="@cheep.CheepId">unsave</button>
                                 </form>
@@ -60,11 +60,11 @@
         <div class="pagination">
             @if (currentPage > 1)
             {
-                <a href="/Saved/?page=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+                <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
             }
             <span>Page @currentPage</span>
 
-            <a href="/Saved/?page=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
+            <a href="/Saved/?pageIndex=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
         </div>
     }
     else
@@ -73,7 +73,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/Saved/?page=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+            <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
         }
         <span>Page @currentPage</span>
     }

--- a/src/Chirp.Web/Pages/Saved.cshtml.cs
+++ b/src/Chirp.Web/Pages/Saved.cshtml.cs
@@ -4,29 +4,16 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Repositories;
 
-public class SavedModel : PageModel
+public class SavedModel : CheepPageModel
 {
-    private readonly IAuthorRepository _authorRepository;
-    private readonly ICheepRepository _cheepRepository;
-    public required List<CheepDTO> Cheeps { get; set; }
 
-    [BindProperty]
-    public string? Follow { get; set; }
-
-    [BindProperty]
-    public string? Unfollow { get; set; }
-    [BindProperty]
-    public long? Unsave { get; set; }
-
-    public SavedModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository)
-    {
-        _cheepRepository = cheepRepository;
-        _authorRepository = authorRepository;
-    }
+    public SavedModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository) 
+        : base(cheepRepository, authorRepository)
+    { }
 
     public async Task<ActionResult> OnGet()
     {
-        string? page = HttpContext.Request.Query["page"];
+        string? page = HttpContext.Request.Query["pageIndex"];
         int pageNum = 1;
         if (page != null)
         {
@@ -40,69 +27,5 @@ public class SavedModel : PageModel
             Cheeps = new List<CheepDTO>();
         }
         return Page();
-    }
-
-    public async Task<ActionResult> OnPostFollowAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-
-
-        var followAuthor = await _authorRepository.GetAuthorByName(Follow!);
-        await _authorRepository.Follow(author!, followAuthor!);
-
-
-        return RedirectToPage("Saved");
-
-    }
-
-    public async Task<ActionResult> OnPostUnfollowAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-        var followAuthor = await _authorRepository.GetAuthorByName(Unfollow!);
-        await _authorRepository.UnFollow(author!, followAuthor!);
-
-
-        return RedirectToPage("Saved");
-    }
-
-    public async Task<ActionResult> OnPostRemoveSaveAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        var cheep = await _cheepRepository.GetCheepById((long)Unsave!);
-
-        await _cheepRepository.RemoveSavedCheep(author!, cheep!);
-
-        return RedirectToPage("Saved");
-    }
-
-    // Curr follows target....
-    public async Task<bool> IsFollowingAsync(string currentUserName, string targetUserName)
-    {
-        // get curr DTO
-        var currentUser = await _authorRepository.GetAuthorByName(currentUserName);
-
-        // get auth DTO
-        var targetUser = await _authorRepository.GetAuthorByName(targetUserName);
-        if (targetUser == currentUser) throw new Exception("You cannot follow this yourself!");
-        if (targetUser == null || currentUser == null) throw new Exception("null :(");
-        var result = await _authorRepository.IsFollowing(currentUser, targetUser);
-
-        return result;
-
     }
 }

--- a/src/Chirp.Web/Pages/Shared/CheepPageModel.cs
+++ b/src/Chirp.Web/Pages/Shared/CheepPageModel.cs
@@ -1,0 +1,154 @@
+namespace Chirp.Web.Pages;
+
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Repositories;
+
+public class CheepPageModel : PageModel
+{
+    protected readonly IAuthorRepository _authorRepository;
+    protected readonly ICheepRepository _cheepRepository;
+    public required List<CheepDTO> Cheeps { get; set; }
+
+    [BindProperty]
+    public string? Text { get; set; }
+    [BindProperty]
+    public string? Follow { get; set; }
+    [BindProperty]
+    public string? Unfollow { get; set; }
+    [BindProperty]
+    public long? Save { get; set; }
+    [BindProperty]
+    public long? Unsave { get; set; }
+
+    // For remembering search & Page when redirecting
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? PageIndex { get; set; }
+
+    public CheepPageModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository)
+    {
+        _cheepRepository = cheepRepository;
+        _authorRepository = authorRepository;
+    }
+
+    public async Task<ActionResult> OnPostCheepAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = User.Identity?.Name;
+        var author = await _authorRepository.GetAuthorByName(user!);
+
+        var cheep = new CheepDTO
+        {
+            Author = author!,
+            Text = Text!,
+            TimeStamp = DateTime.Now
+        };
+        await _cheepRepository.CreateCheep(cheep);
+
+        return RedirectToPage(null, new {search = Search, pageIndex = PageIndex});
+    }
+
+    public async Task<ActionResult> OnPostFollowAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+        var user = User.Identity?.Name;
+        var author = await _authorRepository.GetAuthorByName(user!);
+
+
+        var followAuthor = await _authorRepository.GetAuthorByName(Follow!);
+        await _authorRepository.Follow(author!, followAuthor!);
+
+        return RedirectToPage(null, new {search = Search, pageIndex = PageIndex});
+
+    }
+
+    public async Task<ActionResult> OnPostUnfollowAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = User.Identity?.Name;
+        var author = await _authorRepository.GetAuthorByName(user!);
+        var followAuthor = await _authorRepository.GetAuthorByName(Unfollow!);
+        await _authorRepository.UnFollow(author!, followAuthor!);
+
+        return RedirectToPage(null, new {search = Search, pageIndex = PageIndex});
+    }
+
+    public async Task<ActionResult> OnPostSaveAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+        
+        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
+        var cheep = await _cheepRepository.GetCheepById((long)Save!);
+
+        await _cheepRepository.SaveCheep(author!, cheep!);
+
+        return RedirectToPage(null, new {search = Search, pageIndex = PageIndex});
+    }
+
+    public async Task<ActionResult> OnPostRemoveSaveAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
+        var cheep = await _cheepRepository.GetCheepById((long)Unsave!);
+
+        await _cheepRepository.RemoveSavedCheep(author!, cheep!);
+
+        return RedirectToPage(null, new {search = Search, pageIndex = PageIndex});
+    }
+
+    // Curr follows target....
+    public async Task<bool> IsFollowingAsync(string currentUserName, string targetUserName)
+    {
+        // get curr DTO
+        var currentUser = await _authorRepository.GetAuthorByName(currentUserName);
+
+        // get auth DTO
+        var targetUser = await _authorRepository.GetAuthorByName(targetUserName);
+        if (targetUser == currentUser) throw new Exception("You cannot follow this yourself!");
+        if (targetUser == null || currentUser == null) throw new Exception("null :(");
+        var result = await _authorRepository.IsFollowing(currentUser, targetUser);
+
+        return result;
+
+    }
+
+    public async Task<bool> IsSavedAsync(CheepDTO cheep)
+    {
+        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
+        
+        return await _cheepRepository.IsSaved(author!, cheep);
+
+    }
+
+    public ActionResult OnPostSearch()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        return RedirectToPage(null, new { search = Search });
+    }
+}

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -5,7 +5,7 @@
     Layout = "Shared/_Layout";
     var routeName = HttpContext.GetRouteValue("author");
     int currentPage = 1;
-    var pageQuery = Model.HttpContext.Request.Query["page"];
+    var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);
@@ -19,7 +19,7 @@
     {
         <div class="cheepbox">
             <h3>What's on your mind @(User.Identity!.Name)?</h3>
-            <form method="post" asp-page-handler="Cheep">
+            <form method="post" asp-page-handler="Cheep" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex">
                 <input style="float: left" type="text" asp-for="Text">
                 <input type="submit" value="Share">
             </form>
@@ -40,14 +40,14 @@
                                     var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                     if (isFollowing && User.Identity.Name != cheep.Author.Name)
                                     {
-                                    <form method="post" asp-page-handler="Unfollow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                                 value="@cheep.Author.Name">unfollow</button>
                                     </form>
                                     }
                                     else if (User.Identity.Name != cheep.Author.Name)
                                     {
-                                    <form method="post" asp-page-handler="Follow" style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                                 value="@cheep.Author.Name">follow</button>
                                     </form>
@@ -56,12 +56,12 @@
                                 
                                 var isSaved = await Model.IsSavedAsync(cheep);
                                 if (isSaved) {
-                                    <form method="post" asp-page-handler="RemoveSave" style="display:inline;">
+                                    <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unsave"
                                             value="@cheep.CheepId">unsave</button>
                                     </form>
                                 } else {
-                                    <form method="post" asp-page-handler="Save" style="display:inline;">
+                                    <form method="post" asp-page-handler="Save" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="save"
                                             value="@cheep.CheepId">save</button>
                                     </form>
@@ -77,15 +77,21 @@
         <div class="pagination">
             @if (currentPage > 1)
             {
-                <a href="/@routeName?page=@(currentPage - 1)">Prev</a>
+                <a href="/@routeName?pageIndex=@(currentPage - 1)">Prev</a>
             }
             <span>Page @currentPage</span>
             
-            <a href="/@routeName?page=@(currentPage + 1)">Next</a>
+            <a href="/@routeName?pageIndex=@(currentPage + 1)">Next</a>
         </div>
     }
     else
     {
         <em>There are no cheeps so far.</em>
+        <br/>
+        @if (currentPage > 1)
+        {
+            <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+        }
+        <span>Page @currentPage</span>
     }
 </div>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -4,34 +4,16 @@ using Repositories;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-public class UserTimelineModel : PageModel
+public class UserTimelineModel : CheepPageModel
 {
-    private readonly IAuthorRepository _authorRepository;
-    private readonly ICheepRepository _cheepRepository;
-    public required List<CheepDTO> Cheeps { get; set; }
-    
-    [BindProperty]
-    public string? Text  { get; set; }
-    
-    [BindProperty]
-    public string? Follow { get; set; }
 
-    [BindProperty]
-    public string? Unfollow { get; set; }
-    [BindProperty]
-    public long? Save { get; set; }
-    [BindProperty]
-    public long? Unsave { get; set; }
-
-    public UserTimelineModel(ICheepRepository cheepRepository,IAuthorRepository authorRepository)
-    {
-        _cheepRepository = cheepRepository;
-        _authorRepository = authorRepository;
-    }
+    public UserTimelineModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository) 
+        : base(cheepRepository, authorRepository)
+    { }
 
     public async Task<ActionResult> OnGet(string author)
     {
-        string? page = HttpContext.Request.Query["page"];
+        string? page = HttpContext.Request.Query["pageIndex"];
         int pageNum = 1;
         if (page != null)
         {
@@ -41,93 +23,5 @@ public class UserTimelineModel : PageModel
         Cheeps = await _cheepRepository.ReadCheepsFromFollowers(author, (pageNum - 1) * 32, 32);
         
         return Page();
-    }
-    
-    public async Task<ActionResult> OnPostCheepAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        var user = User.Identity?.Name;
-        Console.WriteLine(user);
-        var author = await _authorRepository.GetAuthorByName(user!);
-
-        var cheep = new CheepDTO
-        {
-            Author = author!,
-            Text = Text!,
-            TimeStamp = DateTime.Now
-        };
-        await _cheepRepository.CreateCheep(cheep);
-        
-        return RedirectToPage("UserTimeline");
-    }
-    
-    public async Task<ActionResult> OnPostUnfollowAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-   
-        var user = User.Identity?.Name;
-        var author = await _authorRepository.GetAuthorByName(user!);
-        var followAuthor = await _authorRepository.GetAuthorByName(Unfollow!);
-        await _authorRepository.UnFollow(author!, followAuthor!);
-
-
-        return RedirectToPage("UserTimeline");
-    }
-
-    public async Task<ActionResult> OnPostSaveAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        var cheep = await _cheepRepository.GetCheepById((long)Save!);
-
-        await _cheepRepository.SaveCheep(author!, cheep!);
-
-        return RedirectToPage("UserTimeline");
-    }
-
-    public async Task<ActionResult> OnPostRemoveSaveAsync()
-    {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        var cheep = await _cheepRepository.GetCheepById((long)Unsave!);
-
-        await _cheepRepository.RemoveSavedCheep(author!, cheep!);
-
-        return RedirectToPage("UserTimeline");
-    }
-    
-    public async Task<bool> IsFollowingAsync(string currentUserName, string targetUserName)
-    {
-        // get curr DTO
-        var currentUser = await _authorRepository.GetAuthorByName(currentUserName);
-
-        // get auth DTO
-        var targetUser = await _authorRepository.GetAuthorByName(targetUserName);
-        if (targetUser == currentUser) throw new Exception("You cannot follow this yourself!");
-        if (targetUser == null || currentUser == null) throw new Exception("null :(");
-        var result = await _authorRepository.IsFollowing(currentUser, targetUser);
-
-        return result;
-    }
-
-    public async Task<bool> IsSavedAsync(CheepDTO cheep)
-    {
-        var author = await _authorRepository.GetAuthorByName(User.Identity!.Name!);
-        
-        return await _cheepRepository.IsSaved(author!, cheep);
-
     }
 }


### PR DESCRIPTION
When clicking on save/follow it used to be that the page number and search was forgotten. This commit fixes that.

Also moved shared methods to a super class called CheepPageModel, such that there isn't as much code duplication. This change may not fit perfectly with the query fix changes, but I wanted to avoid having to copy changes between the different page models, since their methods are exactly the same. 